### PR TITLE
Uncaught TypeError: Cannot read property 'path' of null  if new file or no file was opened

### DIFF
--- a/lib/quick-move-file.coffee
+++ b/lib/quick-move-file.coffee
@@ -116,11 +116,12 @@ class QuickMoveFileView extends View
     @close()
 
   attach: () ->
-    @originalPath = atom.workspace.getActiveEditor().buffer.file.path
-    @miniEditor.setText(@originalPath)
-    atom.workspaceView.append(this)
-    @miniEditor.focus()
-    @miniEditor.scrollToCursorPosition()
+    if atom.workspace.getTextEditors().length > 0 && atom.workspace.getActiveEditor().buffer.file
+        @originalPath = atom.workspace.getActiveEditor().buffer.file.path
+        @miniEditor.setText(@originalPath)
+        atom.workspaceView.append(this)
+        @miniEditor.focus()
+        @miniEditor.scrollToCursorPosition()
 
   close: () ->
     @remove()


### PR DESCRIPTION
Hi, when I tried to run plugin if new (untitled) file was opened or no file was opened I got error because  atom.workspace.getActiveEditor().buffer.file (in case of untitled file) or  atom.workspace.getActiveEditor().buffer (in case of no file) were undefined and plugin would throw error.

I have added check.
